### PR TITLE
Fix container deployment on localhost

### DIFF
--- a/.github/workflows/deploy_firebase_hosting.yml
+++ b/.github/workflows/deploy_firebase_hosting.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ master ]
 jobs:
-  build_and_preview:
+  deploy-firebase:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  gh-pages-deploy:
+  deploy-gh-pages:
     name: Deploying to gh-pages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run_container_tests.yml
+++ b/.github/workflows/run_container_tests.yml
@@ -20,6 +20,4 @@ jobs:
           curl -sI http://localhost:8008/ | grep -o '200 OK'
           curl -s http://localhost:8008/ | grep -o '<title>Slim</title>'
       - name: Test DICOMweb service
-        run: |
-          curl -sI http://localhost:8008/dicomweb/studies
-          curl -sI http://localhost:8008/dicomweb/studies | grep -o '202 Accepted'
+        run: curl -sI http://localhost:8008/dicomweb/studies | grep -o '204 No Content'

--- a/.github/workflows/run_container_tests.yml
+++ b/.github/workflows/run_container_tests.yml
@@ -20,4 +20,6 @@ jobs:
           curl -sI http://localhost:8008/ | grep -o '200 OK'
           curl -s http://localhost:8008/ | grep -o '<title>Slim</title>'
       - name: Test DICOMweb service
-        run: curl -sI http://localhost:8008/dicomweb/studies | grep -o '204 No Content'
+        run: |
+          sleep 20
+          curl -sI http://localhost:8008/dicomweb/studies | grep -o '204 No Content'

--- a/.github/workflows/run_container_tests.yml
+++ b/.github/workflows/run_container_tests.yml
@@ -1,0 +1,23 @@
+name: container tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test-containers:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and run containers using docker compose
+        run: docker-compose up -d
+      - name: Test web page
+        run: |
+          curl -sI http://localhost:8008/ | grep -o '200 OK'
+          curl -s http://localhost:8008/ | grep -o '<title>Slim</title>'
+      - name: Test DICOMweb service
+        run: curl -sI http://localhost:8008/dicomweb/studies | grep -o '202 OK'

--- a/.github/workflows/run_container_tests.yml
+++ b/.github/workflows/run_container_tests.yml
@@ -20,4 +20,4 @@ jobs:
           curl -sI http://localhost:8008/ | grep -o '200 OK'
           curl -s http://localhost:8008/ | grep -o '<title>Slim</title>'
       - name: Test DICOMweb service
-        run: curl -sI http://localhost:8008/dicomweb/studies | grep -o '202 OK'
+        run: curl -sI http://localhost:8008/dicomweb/studies | grep -o '202 Accepted'

--- a/.github/workflows/run_container_tests.yml
+++ b/.github/workflows/run_container_tests.yml
@@ -20,4 +20,6 @@ jobs:
           curl -sI http://localhost:8008/ | grep -o '200 OK'
           curl -s http://localhost:8008/ | grep -o '<title>Slim</title>'
       - name: Test DICOMweb service
-        run: curl -sI http://localhost:8008/dicomweb/studies | grep -o '202 Accepted'
+        run: |
+          curl -sI http://localhost:8008/dicomweb/studies
+          curl -sI http://localhost:8008/dicomweb/studies | grep -o '202 Accepted'

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build_and_test:
+  build-and-test:
 
     runs-on: ubuntu-latest
     strategy:
@@ -15,16 +15,16 @@ jobs:
         node-version: ["14.x", "16.x"]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install dependencies
-      run: yarn install
-    - name: Build with craco
-      run: yarn build
-    - name: Lint with standard
-      run: yarn lint
-    - name: Test with jest
-      run: yarn test
+      - uses: actions/checkout@v2
+      - name: Set up Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Build with craco
+        run: yarn build
+      - name: Lint with standard
+        run: yarn lint
+      - name: Test with jest
+        run: yarn test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye AS lib
+FROM debian:bookworm AS lib
 
 ENV DEBIAN_FRONTEND=noninteractive \
     DEBCONF_NONINTERACTIVE_SEEN=true
@@ -10,14 +10,15 @@ RUN apt-get update && \
     curl \
     dumb-init \
     gnupg \
-    nginx \
-    nodejs && \
+    nginx && \
     apt-get clean
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y --no-install-suggests --no-install-recommends \
+    nodejs \
     yarn && \
     apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,7 @@ RUN NODE_OPTIONS=--max_old_space_size=8192 yarn run build && \
 RUN mkdir -p /var/run/nginx && \
     chown -R nginx:nginx /var/www/html /var/run/nginx /var/lib/nginx /var/log/nginx && \
     chmod -R 0755 /var/www/html /var/run/nginx /var/lib/nginx /var/log/nginx && \
-    rm -r /etc/nginx/conf.d /etc/nginx/sites-available /etc/nginx/sites-enabled && \
-    rm -r /var/www/html/*
+    rm -r /etc/nginx/conf.d /etc/nginx/sites-available /etc/nginx/sites-enabled
 
 COPY etc/nginx/conf.d /etc/nginx/conf.d
 COPY etc/nginx/nginx.conf /etc/nginx/

--- a/etc/nginx/conf.d/local.conf
+++ b/etc/nginx/conf.d/local.conf
@@ -14,7 +14,7 @@ server {
 
     root /var/www/html;
 
-    location /viewer {
+    location / {
         try_files $uri $uri/ /index.html;
         add_header Access-Control-Allow-Origin *;
     }

--- a/public/config/local.js
+++ b/public/config/local.js
@@ -1,6 +1,6 @@
 window.config = {
   // This must match the location configured for web server
-  path: '/viewer',
+  path: '/',
   servers: [
     {
       id: 'local',


### PR DESCRIPTION
- Install node version 14+, which is required for building Slim but is not provided by current Debian distributions
- Expose viewer at root location for simplicity
- Add workflow to test container deployment