### PR TITLE
Sort slides by container identifier

### DIFF
--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -2517,8 +2517,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
           value={null}
           dropdownMatchSelectWidth={false}
           size='small'
-        >
-        </Select.Option>
+        />
       )
       presentationStateMenu = (
         <Menu.SubMenu key='presentation-states' title='Presentation States'>

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -2517,7 +2517,9 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
           value={null}
           dropdownMatchSelectWidth={false}
           size='small'
-        />
+        >
+          {}
+        </Select.Option>
       )
       presentationStateMenu = (
         <Menu.SubMenu key='presentation-states' title='Presentation States'>

--- a/src/data/slides.tsx
+++ b/src/data/slides.tsx
@@ -188,10 +188,10 @@ const createSlides = (
     })
   })
   slides = slides.sort((a, b) => {
-    const imageA = a.volumeImages[0]
-    const imageB = b.volumeImages[0]
-    if (imageA.SeriesNumber != null && imageB.SeriesNumber != null) {
-      return Number(imageA.SeriesNumber) - Number(imageB.SeriesNumber)
+    const imgA = a.volumeImages[0]
+    const imgB = b.volumeImages[0]
+    if (imgA.ContainerIdentifier != null && imgB.ContainerIdentifier != null) {
+      return Number(imgA.ContainerIdentifier) - Number(imgB.ContainerIdentifier)
     } else {
       return 0
     }


### PR DESCRIPTION
Currently slides are sorted by Series Number. The value of this attribute may not be very reliable. Therefore, we instead sort slides by Container Identifier instead. This is a type 1 attribute and required to be present.