### PR TITLE
Add case viewer panel for clinical trial metadata

### DIFF
--- a/src/components/CaseViewer.tsx
+++ b/src/components/CaseViewer.tsx
@@ -14,6 +14,7 @@ import {
 import * as dmv from 'dicom-microscopy-viewer'
 
 import { AnnotationSettings } from '../AppConfig'
+import ClinicalTrial from './ClinicalTrial'
 import DicomWebManager from '../DicomWebManager'
 import Patient from './Patient'
 import Study from './Study'
@@ -165,6 +166,15 @@ class Viewer extends React.Component<ViewerProps, ViewerState> {
       selectedSeriesInstanceUID = volumeInstances[0].SeriesInstanceUID
     }
 
+    let clinicalTrialMenu
+    if (refImage.ClinicalTrialSponsorName != null) {
+      clinicalTrialMenu = (
+        <Menu.SubMenu key='clinical-trial' title='Clinical Trial'>
+          <ClinicalTrial metadata={refImage} />
+        </Menu.SubMenu>
+      )
+    }
+
     return (
       <Layout style={{ height: '100%' }} hasSider>
         <Layout.Sider
@@ -179,16 +189,17 @@ class Viewer extends React.Component<ViewerProps, ViewerState> {
         >
           <Menu
             mode='inline'
-            defaultOpenKeys={['patient', 'case', 'slides']}
+            defaultOpenKeys={['patient', 'study', 'clinical-trial', 'slides']}
             style={{ height: '100%' }}
             inlineIndent={14}
           >
             <Menu.SubMenu key='patient' title='Patient'>
               <Patient metadata={refImage} />
             </Menu.SubMenu>
-            <Menu.SubMenu key='case' title='Case'>
+            <Menu.SubMenu key='study' title='Study'>
               <Study metadata={refImage} />
             </Menu.SubMenu>
+            {clinicalTrialMenu}
             <Menu.SubMenu key='slides' title='Slides'>
               <SlideList
                 client={this.props.client}

--- a/src/components/ClinicalTrial.tsx
+++ b/src/components/ClinicalTrial.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import * as dmv from 'dicom-microscopy-viewer'
+
+import Description from './Description'
+
+interface ClinicalTrialProps {
+  metadata: dmv.metadata.SOPClass
+}
+
+/**
+ * React component representing a DICOM ClinicalTrial Information Entity that displays
+ * common study-level attributes of contained DICOM Slide Microscopy images.
+ */
+class ClinicalTrial extends React.Component<ClinicalTrialProps> {
+  render (): React.ReactNode {
+    const attributes = []
+    if (this.props.metadata.ClinicalTrialSponsorName != null) {
+      // Attributes of Clinical Trial Subject module
+      attributes.push(
+        ...[
+          {
+            name: 'Sponsor Name',
+            value: this.props.metadata.ClinicalTrialSponsorName
+          },
+          {
+            name: 'Protocol ID',
+            value: this.props.metadata.ClinicalTrialProtocolID
+          },
+          {
+            name: 'Protocol Name',
+            value: this.props.metadata.ClinicalTrialProtocolName
+          },
+          {
+            name: 'Site Name',
+            value: this.props.metadata.ClinicalTrialSiteName
+          }
+        ]
+      )
+    }
+    if (this.props.metadata.ClinicalTrialTimePointID != null) {
+      // Attributes of Clinical Trial Study module
+      attributes.push(
+        {
+          name: 'Time Point ID',
+          value: this.props.metadata.ClinicalTrialTimePointID
+        }
+      )
+    }
+      // Attributes of Clinical Trial Subject module
+    return <Description attributes={attributes} />
+  }
+}
+
+export default ClinicalTrial

--- a/src/components/ClinicalTrial.tsx
+++ b/src/components/ClinicalTrial.tsx
@@ -46,7 +46,7 @@ class ClinicalTrial extends React.Component<ClinicalTrialProps> {
         }
       )
     }
-      // Attributes of Clinical Trial Subject module
+    // Attributes of Clinical Trial Subject module
     return <Description attributes={attributes} />
   }
 }

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -2517,8 +2517,7 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
           value={null}
           dropdownMatchSelectWidth={false}
           size='small'
-        >
-        </Select.Option>
+        />
       )
       presentationStateMenu = (
         <Menu.SubMenu key='presentation-states' title='Presentation States'>

--- a/src/components/SlideViewer.tsx
+++ b/src/components/SlideViewer.tsx
@@ -2517,7 +2517,9 @@ class SlideViewer extends React.Component<SlideViewerProps, SlideViewerState> {
           value={null}
           dropdownMatchSelectWidth={false}
           size='small'
-        />
+        >
+          {}
+        </Select.Option>
       )
       presentationStateMenu = (
         <Menu.SubMenu key='presentation-states' title='Presentation States'>

--- a/types/dicom-microscopy-viewer/index.d.ts
+++ b/types/dicom-microscopy-viewer/index.d.ts
@@ -454,6 +454,13 @@ declare module 'dicom-microscopy-viewer' {
       StudyID: string
       StudyDate: string
       StudyTime: string
+      // Clinical Trial Subject module
+      ClinicalTrialSponsorName?: string
+      ClinicalTrialProtocolID?: string
+      ClinicalTrialProtocolName?: string
+      ClinicalTrialSiteName?: string
+      // Clinical Trial Study module
+      ClinicalTrialTimePointID?: string
       // General Series module
       SeriesInstanceUID: string
       SeriesNumber: number | null | undefined
@@ -480,7 +487,7 @@ declare module 'dicom-microscopy-viewer' {
       SpecimenDescriptionSequence: SpecimenDescription[]
       // Optical Path module
       OpticalPathSequence: OpticalPath[]
-      // Equipment
+      // Equipment module
       Manufacturer: string
       ManufacturerModelName: string
       DeviceSerialNumber: string


### PR DESCRIPTION
So far, the case viewer just displays the information about the patient and the study. This PR introduces changes to also display the information about the clinical trial (if available). Specifically, it adds a panel in the case viewer that displays type 1 and 2 attributes of the Clinical Trial Subject and Clinical Trial Study modules.